### PR TITLE
Don't crash on unrecognized certificate extensions

### DIFF
--- a/Seq.Input.CertificateCheck/Extensions/Certificate2Extensions.cs
+++ b/Seq.Input.CertificateCheck/Extensions/Certificate2Extensions.cs
@@ -14,9 +14,8 @@ namespace Seq.Input.CertificateCheck.Extensions
             Regex sanRex = new Regex(@"^DNS Name=(.*)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
             var sanList = from X509Extension ext in cert.Extensions
-                where ext.Oid.FriendlyName.Equals("Subject Alternative Name", StringComparison.Ordinal)
-                let data = new AsnEncodedData(ext.Oid, ext.RawData)
-                let text = data.Format(true)
+                where "2.5.29.17".Equals(ext.Oid.Value, StringComparison.Ordinal) // OID for Subject Alternative Name
+                let text = ext.Format(true)
                 from line in text.Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
                 let match = sanRex.Match(line)
                 where match.Success && match.Groups.Count > 0 && !string.IsNullOrEmpty(match.Groups[1].Value)


### PR DESCRIPTION
`ext.Oid.FriendlyName` is null for extensions that the host version of .NET doesn't recognize, like [ASP.NET Core development cert markers](https://github.com/dotnet/aspnetcore/blob/main/src/Shared/CertificateGeneration/CertificateManager.cs#L21). This causes a `NullReferenceException` when the list of SANs is materialized (and the parsing actually happens).

This checks for the SAN extension by comparing OIDs rather than friendly names, avoiding the crash.

Closes #3.