### PR TITLE
Rewrite the test terminal to log to console and accept arguments

### DIFF
--- a/Terminal/Program.cs
+++ b/Terminal/Program.cs
@@ -1,35 +1,83 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Pipes;
+using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using Seq.Apps;
 using Seq.Input.CertificateCheck;
 using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting.Compact.Reader;
 
 namespace Terminal
 {
-    class Program
+    static class Program
     {
-        static void Main(string[] args)
+        async static Task Main(string[] args)
         {
-            new Program().Run().GetAwaiter().GetResult();
-            Console.ReadLine();
+            if (args.Length == 0)
+            {
+                args = new string[] { "https://api.arke.io/up", "https://app.arke.io/up.json" };
+            }
+            Logger generalLog = new Serilog.LoggerConfiguration().WriteTo.Console(outputTemplate: "[MAIN][{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Properties}{NewLine}{Exception}").CreateLogger();
+            Logger selfLog = new Serilog.LoggerConfiguration().WriteTo.Console(outputTemplate: "[\x1b[43;34mSELF\x1b[0m][{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}").CreateLogger();
+            TestHost testHost = new TestHost { App = new App("1", "test", new Dictionary<string, string>() { }, ""), Logger = selfLog };
+
+            AnonymousPipeServerStream hostPipe = new AnonymousPipeServerStream(PipeDirection.In);
+            CancellationTokenSource cts = new CancellationTokenSource();
+            StreamReader streamLogReader = new StreamReader(hostPipe);
+            Task hostTask = RunSimulatedHost(testHost, args, hostPipe.GetClientHandleAsString(), cts.Token);
+
+            Task<string> exitTask = Task.Run<string>(Console.In.ReadLine);
+
+            while (!cts.IsCancellationRequested)
+            {
+                Task<string> newEventTask = streamLogReader.ReadLineAsync();
+                Task finished = await Task.WhenAny(newEventTask, exitTask);
+                if (finished == exitTask)
+                {
+                    cts.Cancel();
+                }
+                else // newEventTask
+                {
+                    try
+                    {
+                        string sEvent = newEventTask.Result;
+                        JObject jEvent = JObject.Parse(sEvent);
+                        LogEvent lEvent = LogEventReader.ReadFromJObject(jEvent);
+                        generalLog.Write(lEvent);
+                    }
+                    catch(Exception ex)
+                    {
+                        selfLog.Fatal(ex, "HOST: Could not read event.");
+                    }
+                }
+            }
+            await Task.WhenAll(hostTask);
         }
 
-        public async Task Run()
+        static async Task RunSimulatedHost(TestHost testHost, string[] targetUrls, string pipeHandle, CancellationToken cancellationToken)
         {
-            using (StreamWriter writer = new StreamWriter(new MemoryStream()))
+            AnonymousPipeClientStream clientPipe = new AnonymousPipeClientStream(PipeDirection.Out, pipeHandle);
+            using (StreamWriter writer = new StreamWriter(clientPipe))
             {
                 CertificateCheckInput runner = new CertificateCheckInput
                 {
-                    TargetUrl = $"https://api.arke.io/up{Environment.NewLine}https://app.arke.io/up.json",
+                    TargetUrl = string.Join(Environment.NewLine, targetUrls),
                     IntervalSeconds = 5
                 };
-                var testHost = new TestHost {App = new App("1", "test", new Dictionary<string, string>(){}, "")};
 
                 runner.Attach(testHost);
                 runner.Start(writer);
-                Console.ReadLine();
+                try
+                {
+                    await Task.Delay(-1, cancellationToken);
+                }
+                catch (TaskCanceledException) { }
+                runner.Stop();
             }
         }
     }

--- a/Terminal/Terminal.csproj
+++ b/Terminal/Terminal.csproj
@@ -6,6 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="1.0.5" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Seq.Input.CertificateCheck\Seq.Input.CertificateCheck.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
The current version of the testing terminal sends log events to a memory stream, where they are neither visible nor parsed. This version displays log events in the console, formatted in the usual Serilog way, while retaining the ability to press Enter to exit. Additionally, it also displays events from the self-log (which were previously discarded), and while retaining the previous test endpoints as defaults it allows you to specify new test endpoints on the command line, separated by spaces.