### PR TITLE
Release the shared `HttpClientWrapper` semaphore on failed HTTP requests

### DIFF
--- a/Seq.Input.CertificateCheck/HttpClientWrapper.cs
+++ b/Seq.Input.CertificateCheck/HttpClientWrapper.cs
@@ -47,21 +47,25 @@ namespace Seq.Input.CertificateCheck
         public async Task<CertificateInformation> CheckEndpoint(Uri endpoint, CancellationToken cancel)
         {
             await _semaphore.WaitAsync(cancel).ConfigureAwait(false);
-            await _httpClient.GetAsync(endpoint, cancel).ConfigureAwait(false);
-            var result = new CertificateInformation
+            try
             {
-                Subject = _subject,
-                Issuer = _issuer,
-                LastExpiration = _lastExpiration,
-                Thumbprint = _thumbprint,
-                SerialNumber = _serialNumber,
-                SubjectAlternativeNames = _subjectAlternativeNames,
-            };
-            _lastExpiration = null;
-            _semaphore.Release();
-            return result;
+                await _httpClient.GetAsync(endpoint, cancel).ConfigureAwait(false);
+                var result = new CertificateInformation
+                {
+                    Subject = _subject,
+                    Issuer = _issuer,
+                    LastExpiration = _lastExpiration,
+                    Thumbprint = _thumbprint,
+                    SerialNumber = _serialNumber,
+                    SubjectAlternativeNames = _subjectAlternativeNames,
+                };
+                _lastExpiration = null;
+                return result;
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
         }
     }
-    
-    
 }


### PR DESCRIPTION
`HttpClient.GetAsync()` can throw, e.g. when no connection could be made to the target machine, and in various other situations.

This PR ensures that the semaphore is released in these cases.

See also https://github.com/datalust/seq-tickets/discussions/1994